### PR TITLE
Fixed getting game/replay id from /savereplay cmd argument in the game

### DIFF
--- a/modules/score_manager.lua
+++ b/modules/score_manager.lua
@@ -247,9 +247,12 @@ function GetReplayId()
         log.Trace('GetReplayId()... from cmd /syncreplay ' .. tostring(id) )
 
     elseif HasCommandLineArg("/savereplay") then
+        -- /savereplay format is gpgnet://local_ip:port/replay_id/USERNAME.SCFAreplay
+        -- see https://github.com/FAForever/downlords-faf-client/blob/2a69b63eae6e1c28a60419a8627592b4469428f5/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java#L260
         local url = GetCommandLineArg("/savereplay", 1)[1]
-        local lastpos = string.find(url, "/", 20)
-        id = string.sub(url, 20, lastpos-1)
+        local fistpos = string.find(url, "/", 10) + 1
+        local lastpos = string.find(url, "/", fistpos) - 1
+        id = string.sub(url, fistpos, lastpos)
         log.Trace('GetReplayId()... from cmd /savereplay ' .. tostring(id) )
 
     elseif HasCommandLineArg("/replayid") then


### PR DESCRIPTION
Currently in the game instead of current replay id local port is displaying 😄 This PR fixes it.

It seems that it was broken in https://github.com/FAForever/downlords-faf-client/commit/1ae6c7e936305f0336ecb9c324e9fc0560b843c3#diff-3d47503b30b47f5a259049a2e45e1eb555b502bd1f9cc68c936394a0d8fc6f1fR192

_Replicated from https://github.com/FA-mods/SupremeScoreBoard/pull/20_